### PR TITLE
Modify LinkedHashMap references and cast(s) to Map

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 group = 'com.newrelic.instrumentation'
-version = '2.1'
+version = '2.1.1'
 
 dependencies {
   // Agent and Weave API jars:

--- a/src/main/java/com/newrelic/fit/javax/servlet/http/TransactionNamer.java
+++ b/src/main/java/com/newrelic/fit/javax/servlet/http/TransactionNamer.java
@@ -97,8 +97,8 @@ public class TransactionNamer implements ServletInstrumentation {
 		}
 	}
 
-	private LinkedHashMap<Integer, Parameter> parametersToAppend = new LinkedHashMap<Integer, Parameter>();
-	private LinkedHashMap<String, Obfuscation> obfuscationPatterns = new LinkedHashMap<String, Obfuscation>();
+	private Map<Integer, Parameter> parametersToAppend = new LinkedHashMap<Integer, Parameter>();
+	private Map<String, Obfuscation> obfuscationPatterns = new LinkedHashMap<String, Obfuscation>();
 	private LinkedList<Pattern> groupingPatterns = new LinkedList<Pattern>();
 
 	private static final Logger LOGGER = NewRelic.getAgent().getLogger();
@@ -239,7 +239,7 @@ public class TransactionNamer implements ServletInstrumentation {
 		}
 		for (Object thisParamObj : (List<Object>) paramsObj) {
 			if ((thisParamObj != null) && (thisParamObj instanceof Map)) {
-				LinkedHashMap<String, String> thisParamMap = (LinkedHashMap<String, String>) thisParamObj;
+				Map<String, String> thisParamMap = (Map<String, String>) thisParamObj;
 				if ((thisParamMap != null) && thisParamMap.containsKey("name") && thisParamMap.containsKey("type")) {
 					String name = thisParamMap.get("name");
 					String type = thisParamMap.get("type");


### PR DESCRIPTION
Closes #3

Now supports agent versions 6.0.0 through 6.5.0, 7.0.0, and 7.10; all tested on Java 8, 11 and 17.