### PR TITLE
fix-groups

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 group = 'com.newrelic.instrumentation'
-version = '2.1'
+version = '2.1.2'
 
 dependencies {
   // Agent and Weave API jars:


### PR DESCRIPTION
This includes the [content of the other existing PR](https://github.com/newrelic-experimental/newrelic-java-httpservlet-transaction-namer/pull/4), as those changes were necessary for me. That PR changed the version to `2.1.1`, so I've versioned this one `2.1.2`.

Additional changes in my code:
* This pulls the correct **configuration key** when obtaining the group patterns, `httpservlet_transaction_namer.name_grouper.patterns`. The existing code is using the obfuscation patterns key.
* This applies the parameter appending FIRST, so group patterns can use them. 
* I simplified the logic of parameter appending to just append the parameters to URI as grouping will want this and I don't see a reason why it shouldn't go to obfuscation, too.

I believe this now works as intended. Please let me know if I've misunderstood the function of the method.